### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add JsonWebToken as a dependency in your `mix.exs` file:
 
 ```elixir
 defp deps do
-  [{:json_web_token, ">= 0.2"}]
+  [{:json_web_token, ">= 0.2.1"}]
 end
 ```
 


### PR DESCRIPTION
Installing with `0.2` raises an `Version.InvalidRequirementError` error.
