### PR TITLE
Allow RSA keys to be loaded w/o a file

### DIFF
--- a/lib/json_web_token/algorithm/rsa_util.ex
+++ b/lib/json_web_token/algorithm/rsa_util.ex
@@ -1,21 +1,33 @@
 defmodule JsonWebToken.Algorithm.RsaUtil do
   @moduledoc "Encryption keys for test"
 
+  @doc "Load an RSA private key from a string"
+  def private_key(key) do
+    {:RSAPrivateKey, :'two-prime', n, e, d, _p, _q, _e1, _e2, _c, _other} =
+      entry_decode(key)
+    [e, n, d]
+  end
+
   @doc "Load an RSA private key from a pem file"
   def private_key(path_to_keys, filename) do
-    {:RSAPrivateKey, :'two-prime', n, e, d, _p, _q, _e1, _e2, _c, _other} =
-      entry_decode(path_to_keys, filename)
-    [e, n, d]
+    pem_read(path_to_keys, filename)
+    |> private_key
+  end
+
+  @doc "Load an RSA public key from a string"
+  def public_key(key) do
+    {:RSAPublicKey, n, e} = entry_decode(key)
+    [e, n]
   end
 
   @doc "Load an RSA public key from a pem file"
   def public_key(path_to_keys, filename) do
-    {:RSAPublicKey, n, e} = entry_decode(path_to_keys, filename)
-    [e, n]
+    pem_read(path_to_keys, filename)
+    |> public_key
   end
 
-  defp entry_decode(path_to_keys, filename) do
-    pem_read(path_to_keys, filename)
+  defp entry_decode(key) do
+    key
     |> :public_key.pem_decode
     |> List.first
     |> :public_key.pem_entry_decode

--- a/test/json_web_token/algorithm/rsa_util_test.exs
+++ b/test/json_web_token/algorithm/rsa_util_test.exs
@@ -17,4 +17,22 @@ defmodule JsonWebToken.Algorithm.RsaUtilTest do
     assert length(key) == 2
     assert byte_size(Rsa.modulus key) == 261
   end
+
+  test "private key passed in directly" do
+    file_key   = RsaUtil.private_key(@path_to_keys, "private_key.pem")
+    string_key = Path.join(@path_to_keys, "private_key.pem")
+                 |> File.read!
+                 |> RsaUtil.private_key
+
+    assert file_key == string_key
+  end
+
+  test "public key passed in directly" do
+    file_key   = RsaUtil.public_key(@path_to_keys, "public_key.pem")
+    string_key = Path.join(@path_to_keys, "public_key.pem")
+                 |> File.read!
+                 |> RsaUtil.public_key
+
+    assert file_key == string_key
+  end
 end


### PR DESCRIPTION
There are times when the RSA key may not exist in a file on disk, but is already loaded into memory. For those cases, support passing in a raw key string.
