### PR TITLE
Add support for registered RFC 7515 headers

### DIFF
--- a/lib/json_web_token/jwt.ex
+++ b/lib/json_web_token/jwt.ex
@@ -12,6 +12,8 @@ defmodule JsonWebToken.Jwt do
 
   @algorithm_default "HS256"
   @header_default %{typ: "JWT"}
+  # JOSE header types from: https://tools.ietf.org/html/rfc7515
+  @header_jose_keys [:alg, :jku, :jwk, :kid, :x5u, :x5c, :x5t, :"x5t#S256", :typ, :cty, :crit]
 
   @doc """
   Return a JSON Web Token (JWT), a string representing a set of claims as a JSON object that is
@@ -41,7 +43,11 @@ defmodule JsonWebToken.Jwt do
   Filters out unsupported claims options and ignores any encryption keys
   """
   def config_header(options) do
-    Dict.merge(@header_default, alg: algorithm(options))
+    {jose_registered_headers, _other_headers} = Dict.split(options, @header_jose_keys)
+
+    @header_default
+    |> Dict.merge(jose_registered_headers)
+    |> Dict.merge(alg: algorithm(options))
   end
 
   defp algorithm(options) do

--- a/test/json_web_token/jwt_test.exs
+++ b/test/json_web_token/jwt_test.exs
@@ -6,6 +6,7 @@ defmodule JsonWebToken.JwtTest do
   doctest Jwt
 
   @hs256_key "gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr9C"
+  @key_id "test-key"
   @claims %{iss: "joe", exp: 1300819380, "http://example.com/is_root": true}
 
   defp sign_does_verify(options, claims \\ @claims) do
@@ -73,5 +74,13 @@ defmodule JsonWebToken.JwtTest do
 
   test "config_header/1 w/o key, w alg 'none'" do
     assert Jwt.config_header(alg: "none") == %{typ: "JWT", alg: "none"}
+  end
+
+  test "config_header/1 with key and key id includes the key id" do
+    assert Jwt.config_header(key: @hs256_key, kid: @key_id) == %{typ: "JWT", alg: "HS256", kid: "test-key"}
+  end
+
+  test "config_header/1 excludes header that is not registered" do
+    assert Jwt.config_header(key: @hs256_key, notstandard: "value") == %{typ: "JWT", alg: "HS256"} 
   end
 end


### PR DESCRIPTION
If a JWT was signed by a particular key it is necessary to know how to identify that key. RFC 7515 specifies some registered headers for indicating which key was used to sign the JWT. Right now headers like key id (kid) are discarded by the code. This pull request allows for RFC 7515 headers to be included in the JWT header. 
