### PR TITLE
Fix RSA modulus bit size calculation and OTP 20 compatibility

### DIFF
--- a/lib/json_web_token/util.ex
+++ b/lib/json_web_token/util.ex
@@ -26,15 +26,13 @@ defmodule JsonWebToken.Util do
   defp arithmetic_compare("", "", acc), do: acc
 
   @doc """
-  Return the string passed in, unless it is nil or an empty string
+  Return the parameter passed in, unless it is nil or an empty string
 
   ## Example
       iex> JsonWebToken.Util.validate_present("a")
       "a"
   """
-  def validate_present(param), do: validate_present(param, param == "")
-
-  defp validate_present(nil, _), do: raise "Param nil"
-  defp validate_present(_, true), do: raise "Param blank"
-  defp validate_present(param, _), do: param
+  def validate_present(nil), do: raise "Param nil"
+  def validate_present(""), do: raise "Param blank"
+  def validate_present(param), do: param
 end

--- a/test/json_web_token/algorithm/rsa_test.exs
+++ b/test/json_web_token/algorithm/rsa_test.exs
@@ -59,8 +59,9 @@ defmodule JsonWebToken.Algorithm.RsaTest do
   end
 
   test "sign/3 w private_key size < key_bits_min raises" do
+    # private_key_weak.pem holds a 2000-bit key
     private_key = RsaUtil.private_key(@path_to_keys, "private_key_weak.pem")
-    assert byte_size(Rsa.modulus private_key) == 255
+    assert byte_size(Rsa.modulus private_key) == 250
     invalid_key(private_key, "RSA modulus too short")
   end
 

--- a/test/json_web_token/algorithm/rsa_util_test.exs
+++ b/test/json_web_token/algorithm/rsa_util_test.exs
@@ -9,19 +9,19 @@ defmodule JsonWebToken.Algorithm.RsaUtilTest do
   test "private_key" do
     key = RsaUtil.private_key(@path_to_keys, "private_key.pem")
     assert length(key) == 3
-    assert byte_size(Rsa.modulus key) == 261
+    assert byte_size(Rsa.modulus key) == 256
   end
 
   test "public_key" do
     key = RsaUtil.public_key(@path_to_keys, "public_key.pem")
     assert length(key) == 2
-    assert byte_size(Rsa.modulus key) == 261
+    assert byte_size(Rsa.modulus key) == 256
   end
 
   test "private key with ASN.1 header" do
     key = RsaUtil.private_key(@path_to_keys, "private_key_asn1_header.pem")
     assert length(key) == 3
-    assert byte_size(Rsa.modulus key) == 261
+    assert byte_size(Rsa.modulus key) == 256
   end
 
   test "private key passed in directly" do


### PR DESCRIPTION
Using `:crypto.mpint/1` to calculate modulus bit size is wrong, because an `mpint` is not the binary representation of an arbitrary integer. It is a special type of arbitrary integer defined in [RFC 4251](https://www.ietf.org/rfc/rfc4251.txt) padded with metadata.

Since mpints are padded, the current code **overestimates** the length of keys, thus permitting keys below the minimum bit size. For example, a 2048-bit key results in a 2088-bit mpint. 

This pull request replaces `:crypto.mpint/1` with functions that calculate the modulus bit size exactly using Elixir‘s standard library only.

Since using `:crypto.mpint/1` breaks compatibility with OTP 20, this also fixes #20.