### PR TITLE
Allow use of poison 4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule JsonWebToken.Mixfile do
       {:earmark, "~> 1.2", only: :dev},
       {:ex_doc, "~> 0.16", only: :dev},
       {:excoveralls, "~> 0.7", only: :test},
-      {:poison, "~> 3.1"}
+      {:poison, "~> 3.1 or ~> 4.0"}
     ]
   end
 


### PR DESCRIPTION
Just a tiny tweak to allow the use of Poison 4.0 (which works fine) without an override.