### PR TITLE
Support Erlang 24

### DIFF
--- a/lib/json_web_token/algorithm/hmac.ex
+++ b/lib/json_web_token/algorithm/hmac.ex
@@ -18,7 +18,7 @@ defmodule JsonWebToken.Algorithm.Hmac do
   """
   def sign(sha_bits, shared_key, signing_input) do
     validate_params(sha_bits, shared_key)
-    :crypto.hmac(sha_bits, shared_key, signing_input)
+    hmac(sha_bits, shared_key, signing_input)
   end
 
   @doc """
@@ -48,4 +48,10 @@ defmodule JsonWebToken.Algorithm.Hmac do
 
   defp weak_key(true), do: raise "Key size smaller than the hash output size"
   defp weak_key(_), do: :ok
+
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    defp hmac(digest, key, payload), do: :crypto.mac(:hmac, digest, key, payload)
+  else
+    defp hmac(digest, key, payload), do: :crypto.hmac(digest, key, payload)
+  end
 end


### PR DESCRIPTION
Erlang 22.1 introduces `:crypto.mac/4`, 23 deprecates `:crypto.hmac/3` and 24 removes it.

This PR adds support for both functions depending on which one exists.