### PR TITLE
Make sure Poison is included in mix release builds

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,8 @@ defmodule JsonWebToken.Mixfile do
       applications: [
         :crypto,
         :logger,
-        :public_key
+        :public_key,
+        :poison
       ]
     ]
   end


### PR DESCRIPTION
Since this library defines an explicit `applications` list in `mix.exs`,
any dependency not in the list will not be included in a `mix release`
build, unless it happens to be included by the parent project or another
dependency. Since Poison is widely being replaced by Jason, this issue
is becoming likely.

This can be fixed by including `:poison` in `applications`.